### PR TITLE
[#171150452] Change Style Guide to say FastRuby.io instead of FastRuby

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <html>
 
 <head>
-    <title>FastRuby Style Guide</title>
+    <title>FastRuby.io Style Guide</title>
 
     <link rel="stylesheet" type="text/css" href="static/styleguide.css">
     <script src="static/styleguide.js"></script>
@@ -17,7 +17,7 @@
                 <header class="styleguide-header">
                     <nav class="navbar navbar-expand-md">
                         <a class="navbar-brand" href="#">
-                            <img src="vendor/assets/images/logo-1.png" alt="FastRuby Styleguide" />
+                            <img src="vendor/assets/images/logo-1.png" alt="FastRuby.io Styleguide" />
                         </a>
 
                         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavAltMarkup" aria-controls="navbarNavAltMarkup" aria-expanded="false" aria-label="Toggle navigation">
@@ -75,7 +75,7 @@
             <div class="col-sm-9 col-sm-offset-3 main-section">
 
                 <section id="top-section" class="section top-section">
-                    <h1 class="styleguide-title">FastRuby Style Guide</h1>
+                    <h1 class="styleguide-title">FastRuby.io Style Guide</h1>
                     <h2>At <a href="http://www.fastruby.io/" title="FastRuby.io" target="_blank"class="green">FastRuby.io</a>, we believe successful Rails upgrades are shipped one tiny pull request at a time. We love our test-driven process, scrums, pair programming, continuous integration, and sprints.</h2>
                 </section>
 
@@ -109,7 +109,7 @@
                             <h3>&#8595;</h3>
                         </div>
                         <div class="col-sm-12">
-                            <p>P, Weight 300, 16px: FastRuby helps <code>small</code> businesses and entrepreneurs easily <mark>upgrade their Rails applications</mark>. We spend our days <strong>shipping Rails upgrades</strong>while your team focuses on shipping features and bug fixes.</p>
+                            <p>P, Weight 300, 16px: FastRuby.io helps <code>small</code> businesses and entrepreneurs easily <mark>upgrade their Rails applications</mark>. We spend our days <strong>shipping Rails upgrades</strong>while your team focuses on shipping features and bug fixes.</p>
                         </div>
                     </div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -193,7 +193,7 @@
                                                 </g>
                                             </svg>
                                         </div>
-                                        <div><strong>Fast</strong>Ruby</div>
+                                        <div><strong>Fast</strong>Ruby.io</div>
                                     </div>
                                 </div>
                             </div>
@@ -220,7 +220,7 @@
                                                 </g>
                                             </svg>
                                         </div>
-                                        <div><strong>Fast</strong>Ruby</div>
+                                        <div><strong>Fast</strong>Ruby.io</div>
                                     </div>
                                 </div>
                             </div>
@@ -248,7 +248,7 @@
                                             </svg>
                                         </div>
                                         <div class="logo_iso__content">
-                                            <div class="logo_iso"><strong>Fast</strong>Ruby</div>
+                                            <div class="logo_iso"><strong>Fast</strong>Ruby.io</div>
                                             <div><strong>Audit</strong> Tool</div>
                                         </div>
                                     </div>


### PR DESCRIPTION
Pivotal story reference: https://www.pivotaltracker.com/story/show/171150452

This PR:
- Adds ".io" to all logos.