### PR TITLE
Stop capitalizing all h3 elements

### DIFF
--- a/vendor/assets/stylesheets/fastruby/styleguide/2-quarks/_typography.scss
+++ b/vendor/assets/stylesheets/fastruby/styleguide/2-quarks/_typography.scss
@@ -81,10 +81,11 @@ h3 {
   line-height: 1.42;
   letter-spacing: 0.7px;
   margin-bottom: 1.625rem;
-  text-transform: uppercase; }
-  @include respond-above(xs) {
-    h3 {
-      font-size: 1rem; 
+}
+
+@include respond-above(xs) {
+  h3 {
+    font-size: 1rem; 
   } 
 }
 


### PR DESCRIPTION
Hey @nykka,

Here is the PR that replaces https://github.com/ombulabs/fastruby.io/pull/161

Please check it out.

Thanks! 